### PR TITLE
Use a trie to predict and match binding and modal phrases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +315,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -327,6 +357,15 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fid-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28658c0c3420305705adde833a0d2d614207507d013a5f25707553fb2ae2cd"
+dependencies = [
+ "rayon",
 ]
 
 [[package]]
@@ -663,6 +702,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "louds-rs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16a91fb20f74b6d9a758a0103a2884af525a2fa34fbfe19f4b3c5482a4a54e9"
+dependencies = [
+ "fid-rs",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1041,26 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "rayon"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1329,6 +1397,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "simple_logger",
+ "trie-rs",
 ]
 
 [[package]]
@@ -1469,6 +1538,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trie-rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76808f26c7ae42d1222f819f53042b9de30241fd58562eda150ae103d7f53fb7"
+dependencies = [
+ "derivative",
+ "louds-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ reqwest = { version = "0.11.24", default-features = false, features = ["json", "
 serde = { version = "1.0.197", features = ["derive"] }
 serde_yaml = "0.9.32"
 simple_logger = "4.3.3"
+trie-rs = "0.2.0"

--- a/config.yml
+++ b/config.yml
@@ -1,8 +1,10 @@
 model_path: model.april
 ollama_model: mistral
 ollama_endpoint: "http://localhost:11434/api/chat"
+
 wake_phrase: tempest rise
 rest_phrase: tempest rest
+infer_phrase: tempest listen
 
 actions:
   - phrase: UP

--- a/src/config.rs
+++ b/src/config.rs
@@ -339,7 +339,7 @@ impl From<RawConfig> for Config {
         let actions = value
             .actions
             .into_iter()
-            .map(|b| (b.phrase, b.action.into()))
+            .map(|b| (b.phrase.to_uppercase(), b.action.into()))
             .collect();
         Self {
             model_path: value.model_path,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ pub struct RawConfig {
     pub model_path: String,
     pub wake_phrase: String,
     pub rest_phrase: String,
+    pub infer_phrase: String,
     pub actions: Vec<RawBinding>,
     pub ollama_model: String,
     pub ollama_endpoint: String,
@@ -337,8 +338,9 @@ pub enum Mode {
 
 impl From<RawConfig> for Config {
     fn from(value: RawConfig) -> Self {
-        let wake_phrase = value.wake_phrase;
-        let rest_phrase = value.rest_phrase;
+        let wake_phrase = value.wake_phrase.to_uppercase();
+        let rest_phrase = value.rest_phrase.to_uppercase();
+        let infer_phrase = value.infer_phrase.to_uppercase();
         let mut trie_builder = TrieBuilder::new();
         for phrase in value.actions.iter().map(|b| b.phrase.to_uppercase()) {
             trie_builder.push(phrase);
@@ -351,15 +353,15 @@ impl From<RawConfig> for Config {
             .collect();
 
         let mut trie_builder = TrieBuilder::new();
-        trie_builder.push(wake_phrase.to_uppercase());
-        trie_builder.push(rest_phrase.to_uppercase());
-        trie_builder.push("LISTEN");
+        trie_builder.push(wake_phrase.clone());
+        trie_builder.push(rest_phrase.clone());
+        trie_builder.push(infer_phrase.clone());
 
         let abstract_triggers = trie_builder.build();
         let modes = [
-            (wake_phrase.to_uppercase(), Mode::Wake),
-            (rest_phrase.to_uppercase(), Mode::Rest),
-            ("LISTEN".to_owned(), Mode::Infer),
+            (wake_phrase, Mode::Wake),
+            (rest_phrase, Mode::Rest),
+            (infer_phrase, Mode::Infer),
         ]
         .into_iter()
         .collect();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
 use mouse_keyboard_input::key_codes::*;
 use serde::Deserialize;
+use std::collections::BTreeMap;
+use trie_rs::TrieBuilder;
 
 #[derive(Deserialize)]
 pub struct RawConfig {
@@ -11,7 +13,7 @@ pub struct RawConfig {
     pub ollama_endpoint: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub enum Action {
     Keys(Vec<u16>),
     Command(Vec<String>),
@@ -36,15 +38,6 @@ impl From<RawAction> for Action {
     }
 }
 
-impl From<RawBinding> for Binding {
-    fn from(value: RawBinding) -> Self {
-        Self {
-            phrase: value.phrase,
-            action: value.action.into(),
-        }
-    }
-}
-
 #[derive(Deserialize)]
 pub struct RawBinding {
     phrase: String,
@@ -57,14 +50,10 @@ pub struct Config {
     pub model_path: String,
     pub wake_phrase: String,
     pub rest_phrase: String,
-    pub actions: Vec<Binding>,
+    pub actions: BTreeMap<String, Action>,
+    pub word_trie: trie_rs::Trie<u8>,
     pub ollama_model: String,
     pub ollama_endpoint: String,
-}
-
-pub struct Binding {
-    pub phrase: String,
-    pub action: Action,
 }
 
 fn decode_key<S>(key: S) -> u16
@@ -342,12 +331,22 @@ impl From<RawConfig> for Config {
     fn from(value: RawConfig) -> Self {
         let wake_phrase = value.wake_phrase;
         let rest_phrase = value.rest_phrase;
-        let actions = value.actions.into_iter().map(|b| b.into()).collect();
+        let mut trie_builder = TrieBuilder::new();
+        for phrase in value.actions.iter().map(|b| b.phrase.to_uppercase()) {
+            trie_builder.push(phrase);
+        }
+        let word_trie = trie_builder.build();
+        let actions = value
+            .actions
+            .into_iter()
+            .map(|b| (b.phrase, b.action.into()))
+            .collect();
         Self {
             model_path: value.model_path,
             wake_phrase,
             rest_phrase,
             actions,
+            word_trie,
             ollama_model: value.ollama_model,
             ollama_endpoint: value.ollama_endpoint,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ impl TrieMatchBookkeeper {
                     self.matched = new_search;
                 } else {
                     self.matched.clear();
+                    self.matched.push(c);
                 }
             }
 
@@ -87,7 +88,7 @@ impl TrieMatchBookkeeper {
                 self.current_action = self.actions.get(&self.matched).cloned();
                 self.do_action(vd);
             }
-            log::info!("matched {:?}, char: {:?}", self.matched, c);
+            log::debug!("matched {:?}, char: {:?}", self.matched, c);
         }
 
         self.matched.len()

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ pub struct TrieMatchBookkeeper {
 }
 
 impl TrieMatchBookkeeper {
-    fn word_appears_in_phrases(&mut self, phrase: &str, vd: &mut VirtualInput) -> usize {
+    fn word_to_action(&mut self, phrase: &str, vd: &mut VirtualInput) -> usize {
         let chars = phrase.chars();
         for c in chars {
             if self.matched.is_empty() && self.trie.predictive_search(c.to_string()).len() > 0 {
@@ -76,7 +76,6 @@ impl TrieMatchBookkeeper {
                 let mut new_search = self.matched.clone();
                 new_search.push(c);
                 if self.trie.predictive_search(&new_search).len() > 0 {
-                    // self.internal_matched_crib.replace(new_search);
                     self.matched = new_search;
                 } else {
                     self.matched.clear();
@@ -197,7 +196,7 @@ fn main() -> Result<()> {
                 ResultType::RecognitionFinal(Some(tokens)) => {
                     let sentence = tokens_to_string(tokens);
                     if !state.already_commanded && state.listening {
-                        bookkeeper.word_appears_in_phrases(&sentence, &mut device);
+                        bookkeeper.word_to_action(&sentence, &mut device);
                         bookkeeper.do_action(&mut device);
                     }
 
@@ -236,7 +235,7 @@ fn main() -> Result<()> {
                                 state.infer = true;
                                 state.position = sentence.len();
                             }
-                            let position = bookkeeper.word_appears_in_phrases(s, &mut device);
+                            let position = bookkeeper.word_to_action(s, &mut device);
                             if position > 0 {
                                 state.already_commanded = true;
                                 state.position = sentence.len();

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,5 @@
 use std::sync::mpsc::Sender;
 pub struct State {
-    pub position: usize,
     pub length: usize,
     pub already_commanded: bool,
     pub listening: bool,
@@ -11,7 +10,6 @@ pub struct State {
 impl Default for State {
     fn default() -> Self {
         Self {
-            position: 0,
             length: 0,
             already_commanded: true,
             listening: false,
@@ -24,7 +22,6 @@ impl Default for State {
 impl State {
     pub fn clear(&mut self) {
         self.length = 0;
-        self.position = 0;
         self.infer = false;
         self.already_commanded = false;
     }


### PR DESCRIPTION
### Changes
- Instead of iterating over a window of whitespace-split words and looking for a phrase, we use a trie to predict known phrases from the bytes of the input phrase. Improves time complexity from O(n^2) to O(n).
- State management is split up into a bookkeeper which performs actions relevant to the string matching heuristic and the macroscopic state struct.
- The inference phrase is now customizable.
- Built scaffold for custom modes (e.g. editor mode, browser mode, etc.) in the future.